### PR TITLE
Including final </li> in pagination UL

### DIFF
--- a/_includes/themes/bootstrap/post.html
+++ b/_includes/themes/bootstrap/post.html
@@ -42,7 +42,7 @@
       {% if page.next %}
         <li class="next"><a href="{{ BASE_PATH }}{{ page.next.url }}" title="{{ page.next.title }}">Next &rarr;</a></li>
       {% else %}
-        <li class="next disabled"><a>Next &rarr;</a>
+        <li class="next disabled"><a>Next &rarr;</a></li>
       {% endif %}
     </ul>
     <hr>


### PR DESCRIPTION
Noticed the pagination at bottom of the page was missing the closing list element tag for LI class 'next disabled'
