### PR TITLE
fixing markdown type per support article

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ permalink: /:categories/:year/:month/:day/:title
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
 pygments: true
-markdown: redcarpet
+markdown: kramdown
 extensions: [fenced_code_blocks]
 excerpt_separator: "<!--more-->"
 


### PR DESCRIPTION
[Github only supports](https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0) kramdown for the markdown in _config.yml. This resolves the build error emails. 
